### PR TITLE
Improve label positioning

### DIFF
--- a/webview/package.json
+++ b/webview/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "sprotty": "^0.11.1",
-    "sprotty-routing-libavoid": "^1.0.35",
+    "sprotty-routing-libavoid": "^1.0.36",
     "sprotty-vscode-protocol": "^0.2.0",
     "sprotty-vscode-webview": "^0.2.0"
   },

--- a/webview/src/di.config.ts
+++ b/webview/src/di.config.ts
@@ -12,6 +12,7 @@ import {
 } from 'sprotty';
 import { InheritanceEdgeView, ERModelView, EntityNodeView, RelationshipNodeView, NotationEdgeView } from './views';
 import { EntityNode, ERModel, MultiplicityLabel, NotationEdge, RelationshipNode, InheritanceEdge } from './model';
+import { BigerEdgeLayoutPostprocessor } from './layout-postprocessor';
 
 /**
  * Sprotty Dependency Injection container
@@ -25,6 +26,10 @@ const DiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(TYPES.IAnchorComputer).to(LibavoidDiamondAnchor).inSingletonScope();
     bind(TYPES.IAnchorComputer).to(LibavoidEllipseAnchor).inSingletonScope();
     bind(TYPES.IAnchorComputer).to(LibavoidRectangleAnchor).inSingletonScope();
+
+    // custom edge layout postprocessor
+    bind(BigerEdgeLayoutPostprocessor).toSelf().inSingletonScope();
+    bind(TYPES.IVNodePostprocessor).toService(BigerEdgeLayoutPostprocessor);
 
     // change animation speed to 400ms
     rebind(TYPES.CommandStackOptions).toConstantValue({
@@ -84,8 +89,12 @@ export function createDiagramContainer(widgetId: string): Container {
     router.setOptions({
         routingType: RouteType.Orthogonal,
         segmentPenalty: 50,
-        idealNudgingDistance: 10,
-        shapeBufferDistance: 6,
+        // at least height of label to avoid labels overlap if
+        // there two neighbour edges have labels on the position
+        idealNudgingDistance: 24,
+        // 25 - height of label text + label offset. Such shape buffer distance is required to
+        // avoid label over shape
+        shapeBufferDistance: 25,
         nudgeOrthogonalSegmentsConnectedToShapes: true,
         // allow or disallow moving edge end from center
         nudgeOrthogonalTouchingColinearSegments: false,

--- a/webview/src/layout-postprocessor.ts
+++ b/webview/src/layout-postprocessor.ts
@@ -1,0 +1,64 @@
+import { injectable } from "inversify";
+import {
+  EdgeLayoutPostprocessor,
+  isEdgeLayoutable,
+  SEdge,
+  setAttr,
+  SModelElement,
+  SLabel,
+} from "sprotty";
+import { Bounds, toDegrees } from "sprotty-protocol";
+import { VNode } from "snabbdom";
+
+@injectable()
+export class BigerEdgeLayoutPostprocessor extends EdgeLayoutPostprocessor {
+  /** Method works like original EdgeLayoutPostprocessor.decorate,
+   * but improves label positioning in custom code section: labels are
+   * often long(word and more) and in case of placement on left side of vertical
+   * edge segment the label is placed over edge and is also unreadable.
+   * In this case labels are placed on the right side instead.
+   */
+  decorate(vnode: VNode, element: SModelElement): VNode {
+    if (isEdgeLayoutable(element) && element.parent instanceof SEdge) {
+      if (element.bounds !== Bounds.EMPTY) {
+        const placement = this.getEdgePlacement(element);
+        const edge = element.parent;
+        const position = Math.min(1, Math.max(0, placement.position));
+        const router = this.edgeRouterRegistry.get(edge.routerKind);
+        const pointOnEdge = router.pointAt(edge, position);
+        const derivativeOnEdge = router.derivativeAt(edge, position);
+        let transform = "";
+        if (pointOnEdge && derivativeOnEdge) {
+          transform += `translate(${pointOnEdge.x}, ${pointOnEdge.y})`;
+          const angle = toDegrees(
+            Math.atan2(derivativeOnEdge.y, derivativeOnEdge.x)
+          );
+          if (placement.rotate) {
+            let flippedAngle = angle;
+            if (Math.abs(angle) > 90) {
+              if (angle < 0) flippedAngle += 180;
+              else if (angle > 0) flippedAngle -= 180;
+            }
+            transform += ` rotate(${flippedAngle})`;
+            const alignment = this.getRotatedAlignment(
+              element,
+              placement,
+              flippedAngle !== angle
+            );
+            transform += ` translate(${alignment.x}, ${alignment.y})`;
+          } else {
+            let alignment = this.getAlignment(element, placement, angle);
+            // custom code start: improve label positioning
+            if (element instanceof SLabel && alignment.y === 0 && alignment.x < 0) {
+              alignment = { x: -alignment.x, y: alignment.y };
+            }
+            // custom code end
+            transform += ` translate(${alignment.x}, ${alignment.y})`;
+          }
+          setAttr(vnode, "transform", transform);
+        }
+      }
+    }
+    return vnode;
+  }
+}

--- a/webview/src/views.tsx
+++ b/webview/src/views.tsx
@@ -272,9 +272,9 @@ export class NotationEdgeView extends PolylineEdgeView {
             xRectCorrected -= 1;
         }
         if (point.y <= next.y) {
-            yText += 25;
+            yText += 15;
         } else {
-            yText -= 30;
+            yText -= 20;
         }
         if (type === 'comp') {
             return [<svg>

--- a/webview/yarn.lock
+++ b/webview/yarn.lock
@@ -44,36 +44,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@microsoft/fast-element@^1.10.2", "@microsoft/fast-element@^1.6.2", "@microsoft/fast-element@^1.9.0":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.10.2.tgz#34a2faa8a97608e1b7c8024b9aed3deddd5c6ad8"
-  integrity sha512-Nh80AEx/caDe4jhFYNT75sTG4k6MWy1N6XfgyhmejAX0ylivYy0M78WI2JgQOqi2ZRozCiNcpAPLVhYyAVN9sA==
-
-"@microsoft/fast-foundation@^2.38.0", "@microsoft/fast-foundation@^2.41.1":
-  version "2.46.9"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-2.46.9.tgz#a4d4ce50861f71aaef5697746e87b8f66b280507"
-  integrity sha512-jgkVT7bAWIV844eDj3V9cmYFsRIcJ8vMuB4h2SlkJ9EmFbCfimvh6RyAhsHv+bC6QZSS0N0bpZHm5A5QsWgi3Q==
-  dependencies:
-    "@microsoft/fast-element" "^1.10.2"
-    "@microsoft/fast-web-utilities" "^5.4.1"
-    tabbable "^5.2.0"
-    tslib "^1.13.0"
-
-"@microsoft/fast-react-wrapper@^0.1.18":
-  version "0.1.48"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz#aa89c0dfb703c2f71619c536de2342e28b40b8c9"
-  integrity sha512-9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==
-  dependencies:
-    "@microsoft/fast-element" "^1.9.0"
-    "@microsoft/fast-foundation" "^2.41.1"
-
-"@microsoft/fast-web-utilities@^5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz#8e3082ee2ff2b5467f17e7cb1fb01b0e4906b71f"
-  integrity sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==
-  dependencies:
-    exenv-es6 "^1.1.1"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -215,15 +185,6 @@
   version "0.0.25"
   resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.25.tgz#4ebc3e2c9e707ac46aea0becceda79f7738c647c"
   integrity sha512-uqPhTdADjwoCh5Ufbv0M6TZiiP2mqbfJVB4grhVx1k+YeP03LDMOHBWPsNwGKn4/0S5Mq9o1w1GeftvR031Gzg==
-
-"@vscode/webview-ui-toolkit@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.0.0.tgz#b3d13e0a7f4af8df91009a5781faad2bf0e07a80"
-  integrity sha512-/qaHYZXqvIKkao54b7bLzyNH8BC+X4rBmTUx1MvcIiCjqRMxml0BCpqJhnDpfrCb0IOxXRO8cAy1eB5ayzQfBA==
-  dependencies:
-    "@microsoft/fast-element" "^1.6.2"
-    "@microsoft/fast-foundation" "^2.38.0"
-    "@microsoft/fast-react-wrapper" "^0.1.18"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -822,11 +783,6 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
-
-exenv-es6@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exenv-es6/-/exenv-es6-1.1.1.tgz#80b7a8c5af24d53331f755bac07e84abb1f6de67"
-  integrity sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -1710,10 +1666,10 @@ sprotty-protocol@~0.11.0:
   resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-0.11.0.tgz#f8ff89121155520b4e32ea0c05927e7a56173b99"
   integrity sha512-OxRKrKx8mNOxX8CBKsP4epu7YGjT4XvaGwNfAwtVQVh2OPQq98t78A86XGjJThw9axm950QX0KQWGbrzX7FJuQ==
 
-sprotty-routing-libavoid@^1.0.35:
-  version "1.0.35"
-  resolved "https://registry.yarnpkg.com/sprotty-routing-libavoid/-/sprotty-routing-libavoid-1.0.35.tgz#7f3142cb4e507352309d9a6075252e4fc41be596"
-  integrity sha512-ecd//+IWLFe/pG30JyKd2VYVoRbvbWsaN9EQ3xd3ywTa0tv6srlOY4+iJiKtfGMX57mYldEIiJjMx/sRwVyX2w==
+sprotty-routing-libavoid@^1.0.36:
+  version "1.0.36"
+  resolved "https://registry.yarnpkg.com/sprotty-routing-libavoid/-/sprotty-routing-libavoid-1.0.36.tgz#1a843970ed1270c4fb668b03d73dab1eb7ed7668"
+  integrity sha512-0mOwVNoPX+P5IkGdh6dC/JoqdaiFZgJsLVqc4aMPZrGdG3hjiW238iwifSPQhhxm21KKVaQK3BpBsUNkjfSmKQ==
   dependencies:
     inversify "^5.0.1"
     libavoid-js "^0.1.19"
@@ -1796,11 +1752,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tabbable@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
-  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
-
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
@@ -1854,7 +1805,7 @@ ts-loader@^9.2.6:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
-tslib@^1.13.0, tslib@^1.8.1:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5513768/179604847-58dcce5c-8b62-46d8-ad04-578d9c02e00d.png)

After:
![image](https://user-images.githubusercontent.com/5513768/179604913-f624fb43-dbd5-4f30-a88b-0babffd627c5.png)

Two problems with label positioning were solved:
1. Sprotty can place labels on the left side from the vertical edge segment, labels can be long(one word) and as result, they are over edges(e.g. 'Exam' label on the first screenshot).
Solution: custom EdgeLayoutPostprocessor which places labels on the right side from the vertical edge segment.

2. If the center of an edge is on a small edge segment and the label is placed near it, we get the label over the edge again (see 'Work' label on the first screenshot).
Solution: updated sprotty-router-libavoid to 1.0.36, it supports `minimalSegmentLengthForChildPosition` parameter and is 20 by default.