### PR TITLE
fix for child spawn problem on extension launch

### DIFF
--- a/extension/src/erdiagram-lsp-extension.ts
+++ b/extension/src/erdiagram-lsp-extension.ts
@@ -58,15 +58,26 @@ export class ERDiagramLspVscodeExtension extends SprottyLspEditVscodeExtension {
     protected activateLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         const executable = process.platform === 'win32' ? 'erdiagram-language-server.bat' : 'erdiagram-language-server';
         const languageServerPath = path.join('server', 'erdiagram-language-server', 'bin', executable);
-        const serverLauncher = context.asAbsolutePath(languageServerPath);
+        let serverLauncher;
+        if (process.platform === 'win32') {
+            serverLauncher = '"' + context.asAbsolutePath(languageServerPath) + '"';
+        } else {
+            serverLauncher = context.asAbsolutePath(languageServerPath);
+        }
         const serverOptions: ServerOptions = {
             run: {
                 command: serverLauncher,
-                args: ['-trace']
+                args: ['-trace'],
+                options: {
+                    shell: process.platform === 'win32'
+                }
             },
             debug: {
                 command: serverLauncher,
-                args: ['-trace']
+                args: ['-trace'],
+                options: {
+                    shell: process.platform === 'win32'
+                }
             }
         };
         const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
## Describe your changes
To run the extension, a small change is needed to launch the language server due to the breaking changes to the underlying nodejs version change introduced in vscode 1.92 and beyond.

For Window users (unsure about mac and linux), the extension would fail to spawn a child when launching. The fix in this patch follows guidelines by https://github.com/gitkraken/vscode-gitlens/issues/3387 and passes an additional option to the launching of the child process. In this case, the `shell` keyword needs to be set to true for window users. Also, the path to the jar needs to be wrapped in quotations, as the path can contain spaces. I am unsure if this is necessary for non-window users, so I avoided changing the previous workflow for these users.

## Fixes # (issue ID)
- #67 